### PR TITLE
Added Migration for Argument Mapper. 

### DIFF
--- a/migrations/20190107103315_add_AM_to_tools.js
+++ b/migrations/20190107103315_add_AM_to_tools.js
@@ -1,0 +1,18 @@
+
+exports.up = function(knex, Promise) {
+    return knex("tools").insert([
+        {
+            name: "Argument Mapper", 
+            url: "www.google.com", 
+            description: "Lorem Ipsum Argument Mapper Lorem Ipsum Argument Mapper",
+            username: "AMusername",
+            password: "AMpassword"
+        },
+    ]);
+};
+
+exports.down = function(knex, Promise) {
+  return knex("tools")
+        .where("name", "Argument Mapper")
+        .del()
+};


### PR DESCRIPTION
This seems to be the easiest way to add a tool to the database without wiping out everything else. Future Developer may follow suit using this pattern to add to, modify, or delete from the tools table.